### PR TITLE
Check if correct object is defined

### DIFF
--- a/tasks/upgrade_now.yml
+++ b/tasks/upgrade_now.yml
@@ -20,7 +20,7 @@
   shell: sleep 2 && shutdown -r now "Ansible updates triggered"
   async: 1
   poll: 0
-  when: require_reboot is defined and require_reboot.stat.exists
+  when: require_reboot.stat is defined and require_reboot.stat.exists
 
 - name: upgrade_now | Check and set if ansible_ssh_host is set
   set_fact:
@@ -41,7 +41,7 @@
     search_regex=OpenSSH
   connection: local
   become: False
-  when: require_reboot is defined and require_reboot.stat.exists
+  when: require_reboot.stat is defined and require_reboot.stat.exists
 
 - name: upgrade_now | pause a little to ensure everything is running
   pause:


### PR DESCRIPTION
The `require_reboot` variable will be defined, because `register` always registers it, even if `when` condition is `False`. However, `stat` object inside it exists only if the `stat` task was executed inside registering task, that is why it is better to check if `require_reboot.stat` exists, rather than just `require_reboot`.

```
when: require_reboot is defined and require_reboot.stat.exists
      ( ^^^ always true       )     ( ^^^ python fails here  )
```