### PR TITLE
Add skip reboot feature

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,6 +37,7 @@ unattended_download_limit   : false  # Set to Integer representing kb/sec limit 
 
 ## *********** Update your system***********
 upgrade_now                     : False  # Enable upgrade now feature
+upgrade_now_skip_reboot         : False  # Skip reboot step
 upgrade_now_force               : False  # Force upgrade and reboot if needed all checks will be ignored
 upgrade_now_ssh_port            : 22
 upgrade_now_pause_after_reboot  : 10 # Sleep time after machine reboots

--- a/tasks/upgrade_now.yml
+++ b/tasks/upgrade_now.yml
@@ -14,7 +14,7 @@
   stat:
     path="{{ upgrade_now_apt_reboot_file }}"
   register: require_reboot
-  when: not first_boot_stat.stat.exists or upgrade_now_force
+  when: not upgrade_now_skip_reboot and (not first_boot_stat.stat.exists or upgrade_now_force) 
 
 - name: upgrade_now | Reboot now
   shell: sleep 2 && shutdown -r now "Ansible updates triggered"


### PR DESCRIPTION
Add option to skip reboot, in cases when it is not required, e.g. when baking AMI.